### PR TITLE
bump: update gemini site for r1beta4

### DIFF
--- a/content/get-haiku/index.gmi
+++ b/content/get-haiku/index.gmi
@@ -20,13 +20,6 @@ Provided by Haiku, Inc.
 => https://s3.us-east-1.wasabisys.com/haiku-release/r1beta4/haiku-r1beta4-x86_gcc2h-anyboot.iso iso, 32-bit, x86
 => https://s3.us-east-1.wasabisys.com/haiku-release/r1beta4/haiku-r1beta4-x86_64-anyboot.iso iso, 64-bit, x86_64
 
-## Stockholm, Sweden Mirror
-
-Provided by tnonline.net
-
-=> https://mirrors.tnonline.net/haiku/haiku-release/r1beta4/haiku-r1beta4-x86_gcc2h-anyboot.iso iso, 32-bit, x86
-=> https://mirrors.tnonline.net/haiku/haiku-release/r1beta4/haiku-r1beta4-x86_64-anyboot.iso iso, 64-bit, x86_64
-
 ## Australia Mirror
 
 Provided by Australia's Academic and Research Network, aarnet.edu.au

--- a/content/get-haiku/index.gmi
+++ b/content/get-haiku/index.gmi
@@ -1,38 +1,38 @@
 # Get Haiku!
 
-> The current official release of Haiku is R1 / Beta 3
+> The current official release of Haiku is R1 / Beta 4
 
 Additional information including release notes can be found on our website.
 
 => https://www.haiku-os.org/get-haiku Get Haiku!
 
-# Haiku R1 / Beta 3
+# Haiku R1 / Beta 4
 
-* Version: R1/beta3
-* Release Date: July 25th, 2021
+* Version: R1/beta4
+* Release Date: TODO
 
-=> r1b3-notes.gmi Release Notes
+=> r1b4-notes.gmi Release Notes
 
 ## US Mirror
 
 Provided by Haiku, Inc.
 
-=> https://s3.us-east-1.wasabisys.com/haiku-release/r1beta3/haiku-r1beta3-x86_gcc2h-anyboot.iso iso, 32-bit, x86
-=> https://s3.us-east-1.wasabisys.com/haiku-release/r1beta3/haiku-r1beta3-x86_64-anyboot.iso iso, 64-bit, x86_64
+=> https://s3.us-east-1.wasabisys.com/haiku-release/r1beta4/haiku-r1beta4-x86_gcc2h-anyboot.iso iso, 32-bit, x86
+=> https://s3.us-east-1.wasabisys.com/haiku-release/r1beta4/haiku-r1beta4-x86_64-anyboot.iso iso, 64-bit, x86_64
 
 ## Stockholm, Sweden Mirror
 
 Provided by tnonline.net
 
-=> https://mirrors.tnonline.net/haiku/haiku-release/r1beta3/haiku-r1beta3-x86_gcc2h-anyboot.iso iso, 32-bit, x86
-=> https://mirrors.tnonline.net/haiku/haiku-release/r1beta3/haiku-r1beta3-x86_64-anyboot.iso iso, 64-bit, x86_64
+=> https://mirrors.tnonline.net/haiku/haiku-release/r1beta4/haiku-r1beta4-x86_gcc2h-anyboot.iso iso, 32-bit, x86
+=> https://mirrors.tnonline.net/haiku/haiku-release/r1beta4/haiku-r1beta4-x86_64-anyboot.iso iso, 64-bit, x86_64
 
 ## Australia Mirror
 
 Provided by Australia's Academic and Research Network, aarnet.edu.au
 
-=> https://mirror.aarnet.edu.au/pub/haiku/r1beta3/haiku-r1beta3-x86_gcc2h-anyboot.iso iso, 32-bit, x86
-=> https://mirror.aarnet.edu.au/pub/haiku/r1beta3/haiku-r1beta3-x86_64-anyboot.iso iso, 64-bit, x86_64
+=> https://mirror.aarnet.edu.au/pub/haiku/r1beta4/haiku-r1beta4-x86_gcc2h-anyboot.iso iso, 32-bit, x86
+=> https://mirror.aarnet.edu.au/pub/haiku/r1beta4/haiku-r1beta4-x86_64-anyboot.iso iso, 64-bit, x86_64
 
 # Nightly Images
 

--- a/content/get-haiku/r1b4-notes.gmi
+++ b/content/get-haiku/r1b4-notes.gmi
@@ -1,0 +1,212 @@
+# Haiku, R1/Beta3
+
+The third beta for Haiku R1 marks twenty months of hard work to improve Haiku's hardware support and its overall stability. Since Beta 2, there have been 87 contributors with over 1,248 code commits in total. More than 251 bugs and enhancement tickets have been resolved for this release.
+
+Please keep in mind that this is beta-quality software, which means it is feature complete but still contains known and unknown bugs. While we are mostly confident in its stability, we cannot provide assurances against data loss.
+
+To download Haiku or learn how to upgrade from R1/beta2, see "Get Haiku!". For press inquiries, see "Press contact".
+
+=> /get-haiku/ Get Haiku!
+
+## System requirements
+
+This release is available on the x86 32-bit platform, as well as the x86_64 platform.
+
+> Note that BeOS R5 compatibility is only provided on the 32-bit images.
+
+``` Requirements Table
++---------------------------------+--------------------------------------+
+| Minimum (32-bit)                | Recommended (64-bit)                 |
++---------------------------------+--------------------------------------+
+| Processor: Intel Pentium II     | Processor: Intel Core i3             |
+|            AMD Athlon           |            AMD Phenom II             |
+| Memory:    384 MiB              | Memory:    2 GiB                     |
+| Monitor:   800x600              | Monitor:   1366x768                  |
+| Storage:   3 GiB                | Storage:   16 GiB                    |
++---------------------------------+--------------------------------------+
+```
+
+> SSE2 support is required to use the WebPositive web browser. On machines where this is not available, it is recommended to install the NetSurf browser instead.
+
+# Highlights
+
+## Installation process
+
+* It's possible to use Installer to cleanly reset an existing system by installing over it.
+* It's possible to go back to FirstBootPrompt from Installer if you change your mind and want to use live mode.
+* Improvements to DriveSetup GUI and backend to make disk partitioning easier and more reliable.
+
+## Package management
+
+* The system update can now resume downloads in case it is interrupted.
+* Support for running a script on package uninstall
+* Performance improvements for package icons handling in HaikuDepot
+* Numerous stability and user improvements to HaikuDepot
+* Deprecated Python 2 and switched to Python 3.7 as the default version of Python shipped with Haiku
+
+## User interface
+
+* Implement center and right-aligned BTextView support and various fixes to BTextControl for better handling of cursor movements.
+* Improved support for dark color scheme
+* Integration of PadBlocker in Input preferences (disable touchpad when keyboard is used)
+* Scale scroll bars according to UI/font size
+* Several changes to make localization better
+* Support of CPUs with more than 8 cores in ProcessController load graphs
+* Display CPU manufacturer logo in Pulse
+* Numerous stability and compatibility improvements to MediaPlayer
+* The application icon in the shutdown dialog is animated when the application does not want to close
+
+## app_server (graphics server)
+
+* Various fixes for clipping and flickering problems in app_server
+* Support for more composite drawing operations (used in the web browser for javascript canvas support)
+* Fixed the font overlay/fallback system and added an extra font to it (Noto Sans Symbols 2)
+* Reworked memory management and fixed some memory corruption bugs
+
+# Web browser
+
+* Accept-Language header was missing, breaking some websites
+* A dark "Document Color" system theme color triggers "dark mode" on websites
+* "Search the web" context menu works again
+* Easy selection of default search engine from a list of common ones
+* Search shortcuts, for example typing "w Haiku" in the address bar will open the Wikipedia article about Haiku.
+* WebKit engine (haikuwebkit) upgraded to WebKit 612.1.21
+
+# APIs
+
+* Introduced a new version of the "net services" APIs (http and gopher clients). It is moved to a static library, allowing us to make changes without breaking applications. Existing applications can continue to use the old API (present until beta2) but that will be removed later. It is recommended to adjust and recompile such applications before the next Haiku release.
+
+## Storage and file systems
+
+* Improvements to XFS driver
+* Fixed a kernel panic in the NFS driver
+* Support Sun VTOC partition tables
+
+## BeOS compatibility
+
+* Reworked the initialization of the Locale Kit and Translation Kit to fix deadlocks when both are used (affected applications: BeLive, Tracker)
+* Implemented B_OUTLINE_RESIZE to allow windows to stop redrawing during resize operations
+* BeControlLook that alters controls to resemble BeOS R5.
+
+## POSIX compatibility
+
+* Added mlock and munlock.
+* Removed a limitation on the number of dead joinable threads
+* Fixed pselect interaction with signals
+* Fixed the return code of fsync when called on fifo pipes
+* asprintf is moved to libbsd because it is not a standard POSIX function
+* Added exp10, exp10f and exp10l to math.h (only in {{{_GNU_SOURCE}}})
+* Fixed behavior of write() in O_APPEND mode
+* Implemented posix_fallocate
+* Added ut_host in utmpx.h
+* Added ppoll()
+* Implemented a missing escape sequence in terminal to insert repeated characters
+
+# System performance
+
+* Optimize create_area to avoid O(n^2^) algorithm
+* Optimize BMenuItem::RemoveItem to be O(1) instead of O(n)
+* Improvements on cpufreq management
+* Improve caching in MediaPlayer to allow playing 4K video
+* Implement selective ACK (SACK) to improve TCP performance on lossy network links
+
+## Internationalization
+
+This release adds the Czech translation for all the system and bundled applications. With this addition, Haiku is now available in 28 different languages.
+
+## Hardware compatibility
+
+## Sound
+
+* Improved es1370 audio drivers
+* Improved hda audio drivers
+
+## Mass storage
+
+* Support for SD/MMC readers on the PCI bus (SDHCI)
+* Improved ramfs driver stability
+* Improved NVMe driver performance
+
+## Network
+
+* Improved virtio driver performance
+* Updated wireless network drivers to match with FreeBSD 13
+* Remove the "wavelan" WiFi driver which supported only some very old 11Mbps Wifi cards
+
+## USB
+
+* Improved USB 3 drivers
+
+## Graphics
+
+* Improved Intel_Extreme drivers (Gen4 through Gen7)
+* Improved NVIDIA GeForce 6200-6400 drivers
+
+## New Contributors
+
+Haiku saw 34 new contributors to the source code since R1/beta2
+
+* Máximo Castañeda
+* Jaidyn Ann
+* Han Pengfei
+* David Sebek
+* Coldfirex
+* Lt-Henry
+* Jeremy Visser
+* beaglejoe
+* Sylvain78
+* roired
+* Pawan Wadhwani
+* Mitsunori YOSHIDA
+* Jessica Tallon
+* Andriy Voskoboinyk
+* Anarchos
+* syedsouban
+* Siddhant Gupta
+* Shannon Mackey
+* Sean Long
+* Saloni
+* ROIRED XSoto
+* rofl0r
+* Oishika Pradhan
+* Mark Barnett
+* Maciej Bałuta
+* jpdw
+* jiceland
+* JadedTuna
+* HrithikKumar49
+* Heinrich Schuchardt
+* Daniel Schaefer
+* Bailey Carlson
+* Andriy Gapon
+* Adam Fowler
+
+## Source code
+
+The source code of Haiku itself can be accessed from GitHub at https://github.com/haiku/haiku or via Haiku's Git instance at https://git.haiku-os.org.
+
+=> https://github.com/haiku/haiku https://github.com/haiku/haiku
+=> https://git.haiku-os.org https://git.haiku-os.org
+
+## Reporting issues
+
+There are almost 3,600 open tickets on Haiku's bug tracker and over 13,432 closed items.  If you find what you believe to be an issue, please search the bug tracker to see if it has already been reported, and if not, file a new ticket at https://dev.haiku-os.org/.
+
+=> https://dev.haiku-os.org/ https://dev.haiku-os.org/
+
+For information about major issues that have been fixed since the release, visit https://dev.haiku-os.org/wiki/R1/Beta3/ReleaseAddendum.
+
+=> https://dev.haiku-os.org/wiki/R1/Beta3/ReleaseAddendum https://dev.haiku-os.org/wiki/R1/Beta3/ReleaseAddendum
+
+For more help, take the 'Quick Tour' and read the 'User Guide', both linked on the Haiku desktop. WebPositive opens by default with our 'Welcome' page which provides useful information and many helpful links, as does the Haiku Project's website at https://www.haiku-os.org.
+
+=> https://www.haiku-os.org https://www.haiku-os.org
+
+For support and/or help with anything related to Haiku, feel free to post on our forums at https://discuss.haiku-os.org, or send a message to our general mailing list at https://www.freelists.org/list/haiku so our friendly community may assist you.
+
+=> https://discuss.haiku-os.org https://discuss.haiku-os.org
+=> https://www.freelists.org/list/haiku https://www.freelists.org/list/haiku
+
+## Press contact
+
+Press inquiries may be directed to our team via email at contact@haiku-os.org

--- a/content/get-haiku/r1b4-notes.gmi
+++ b/content/get-haiku/r1b4-notes.gmi
@@ -1,10 +1,12 @@
-# Haiku, R1/Beta3
+# Haiku, R1/Beta4
 
-The third beta for Haiku R1 marks twenty months of hard work to improve Haiku's hardware support and its overall stability. Since Beta 2, there have been 87 contributors with over 1,248 code commits in total. More than 251 bugs and enhancement tickets have been resolved for this release.
+The fourth beta for Haiku R1 marks over a year and a half of hard work to improve Haiku's hardware support and its overall stability. Over 400 bugs and enhancement tickets have been resolved for this release.
 
 Please keep in mind that this is beta-quality software, which means it is feature complete but still contains known and unknown bugs. While we are mostly confident in its stability, we cannot provide assurances against data loss.
 
-To download Haiku or learn how to upgrade from R1/beta2, see "Get Haiku!". For press inquiries, see "Press contact".
+For most of this release cycle, waddlesplash was employed as a contractor to work on Haiku. His contract is presently ongoing, supported by the generous donations of readers like you to Haiku, Inc., a 501(c)3 non-profit.
+
+To download Haiku or learn how to upgrade from R1/beta3, see "Get Haiku!". For press inquiries, see "Press contact".
 
 => /get-haiku/ Get Haiku!
 
@@ -26,187 +28,139 @@ This release is available on the x86 32-bit platform, as well as the x86_64 plat
 +---------------------------------+--------------------------------------+
 ```
 
-> SSE2 support is required to use the WebPositive web browser. On machines where this is not available, it is recommended to install the NetSurf browser instead.
+# New features
 
-# Highlights
+## Improved HiDPI support
 
-## Installation process
+Previous releases of Haiku partially supported HiDPI scaling merely by changing the system font size; however, not all metrics were actually tied to the font size as they should be, and not all applications actually obeyed the system-set font size. Much work over the past release cycle has gone into rectifying these problems, and as you can now see in the above screenshots, most native applications now scale sufficiently well. There are still some weak spots, but these should be resolved in time.
 
-* It's possible to use Installer to cleanly reset an existing system by installing over it.
-* It's possible to go back to FirstBootPrompt from Installer if you change your mind and want to use live mode.
-* Improvements to DriveSetup GUI and backend to make disk partitioning easier and more reliable.
+Additionally, on first boot Haiku now attempts to automatically detect if you are on a HiDPI display and set appropriate sizes. These can of course be adjusted with the font size settings of the Appearance preferences. For now, it is not possible for changes to these settings to take effect without a reboot.
 
-## Package management
+Some ported applications have already been patched or updated to correctly read and use Haiku’s own settings, but not all of them yet.
 
-* The system update can now resume downloads in case it is interrupted.
-* Support for running a script on package uninstall
-* Performance improvements for package icons handling in HaikuDepot
-* Numerous stability and user improvements to HaikuDepot
-* Deprecated Python 2 and switched to Python 3.7 as the default version of Python shipped with Haiku
+## Flat decorator
 
-## User interface
+For those who find Haiku’s use of gradients a little “much”, there is now a “flat” decorator & control look available. It does not come installed by default, but can be added via the “Haiku Extras” package, and then enabled in the Appearance preferences. (The colors shown are not yet included by default; you will have to use ThemeManager or adjust some preferences manually in order to get a like appearance.)
 
-* Implement center and right-aligned BTextView support and various fixes to BTextControl for better handling of cursor movements.
-* Improved support for dark color scheme
-* Integration of PadBlocker in Input preferences (disable touchpad when keyboard is used)
-* Scale scroll bars according to UI/font size
-* Several changes to make localization better
-* Support of CPUs with more than 8 cores in ProcessController load graphs
-* Display CPU manufacturer logo in Pulse
-* Numerous stability and compatibility improvements to MediaPlayer
-* The application icon in the shutdown dialog is animated when the application does not want to close
+## Thumbnails in Tracker
 
-## app_server (graphics server)
+Requested for many years and now finally a reality: “Tracker”, Haiku’s native file manager (originally inherited from BeOS), now supports generating and displaying image thumbnails. The thumbnails themselves are stored in extended attributes of the files themselves, which means applications can create their own thumbnails for custom filetypes, if they want (for example, a screenshot might be the thumbnail of an emulator’s save-state.)
 
-* Various fixes for clipping and flickering problems in app_server
-* Support for more composite drawing operations (used in the web browser for javascript canvas support)
-* Fixed the font overlay/fallback system and added an extra font to it (Noto Sans Symbols 2)
-* Reworked memory management and fixed some memory corruption bugs
+## Support for (some) USB WiFi devices
 
-# Web browser
+Most “RTL” and some “RA” USB WiFi devices (the two most common device families, very often repackaged under other names) are now supported in Haiku thanks to the import of the relevant drivers from FreeBSD, and the implementation of FreeBSD’s basic USB-related APIs in Haiku’s FreeBSD driver compatibility layer. There is one major limitation: these devices must be connected before Haiku is booted; they will not be detected if connected after the boot is finished.
 
-* Accept-Language header was missing, breaking some websites
-* A dark "Document Color" system theme color triggers "dark mode" on websites
-* "Search the web" context menu works again
-* Easy selection of default search engine from a list of common ones
-* Search shortcuts, for example typing "w Haiku" in the address bar will open the Wikipedia article about Haiku.
-* WebKit engine (haikuwebkit) upgraded to WebKit 612.1.21
+## WiFi drivers from OpenBSD
 
-# APIs
+The iwm and iwx drivers from OpenBSD, along with OpenBSD’s 802.11 stack, have been imported into Haiku (and given the native names idualwifi7260 and iaxwifi200 respectively.) These provide support for Intel’s “Dual Band” and “AX” families of WiFi hardware. FreeBSD’s version of the iwm driver had been available on Haiku for years, but only supported 802.11a/b/g (not even 802.11n, much less 802.11ac!) and was not very reliable; meanwhile the iwx driver has no direct FreeBSD equivalent.
 
-* Introduced a new version of the "net services" APIs (http and gopher clients). It is moved to a static library, allowing us to make changes without breaking applications. Existing applications can continue to use the old API (present until beta2) but that will be removed later. It is recommended to adjust and recompile such applications before the next Haiku release.
+This means Haiku is only the third open-source operating system (to the best of our knowledge) after Linux and OpenBSD to support 802.11ac WiFi, as not even FreeBSD supports it (yet?) despite having worked on it intermittently for years.
 
-## Storage and file systems
+Supporting these drivers required the addition of an “OpenBSD compatibility layer”, which builds on top of the existing FreeBSD compatibility layer. OpenBSD supporting hardware that FreeBSD does not seems to be an increasing trend (there are some more ethernet and WiFi cards that OpenBSD has drivers for which Haiku could stand to gain), and this work paves the way for such future developments.
 
-* Improvements to XFS driver
-* Fixed a kernel panic in the NFS driver
-* Support Sun VTOC partition tables
 
-## BeOS compatibility
+## USB-RNDIS tethering support
 
-* Reworked the initialization of the Locale Kit and Translation Kit to fix deadlocks when both are used (affected applications: BeLive, Tracker)
-* Implemented B_OUTLINE_RESIZE to allow windows to stop redrawing during resize operations
-* BeControlLook that alters controls to resemble BeOS R5.
+A new driver has been added to support “RNDIS” ethernet tethering, which is the most common kind Android phones use when selecting “USB tethering”. It is enabled by default, and supports hot-plugging.
 
-## POSIX compatibility
+## New NTFS driver
 
-* Added mlock and munlock.
-* Removed a limitation on the number of dead joinable threads
-* Fixed pselect interaction with signals
-* Fixed the return code of fsync when called on fifo pipes
-* asprintf is moved to libbsd because it is not a standard POSIX function
-* Added exp10, exp10f and exp10l to math.h (only in {{{_GNU_SOURCE}}})
-* Fixed behavior of write() in O_APPEND mode
-* Implemented posix_fallocate
-* Added ut_host in utmpx.h
-* Added ppoll()
-* Implemented a missing escape sequence in terminal to insert repeated characters
+The NTFS filesystem driver (which is a wrapper around the NTFS-3G library) was completely rewritten. The old one hearkened back to the BeOS days and had not kept up with development: it did not support any kind of caching, incorrectly handled file deletions in a way that caused kernel panics, did not support memory-mapping files (making git usage impossible on NTFS partitions), and had plenty of other issues besides.
 
-# System performance
+The new diver is much more idiomatic, supports the major layers of Haiku’s common filesystem caching mechanisms, and resolves all known issues and major missing features the previous one was plagued with. Since it is not FUSE-based (like NTFS-3G is on Linux) but runs in kernel-mode, it is competitive for performance with the other fully native filesystem drivers.
 
-* Optimize create_area to avoid O(n^2^) algorithm
-* Optimize BMenuItem::RemoveItem to be O(1) instead of O(n)
-* Improvements on cpufreq management
-* Improve caching in MediaPlayer to allow playing 4K video
-* Implement selective ACK (SACK) to improve TCP performance on lossy network links
 
-## Internationalization
+## AVIF translator
 
-This release adds the Czech translation for all the system and bundled applications. With this addition, Haiku is now available in 28 different languages.
+There is now an AVIF image translator available by default, providing both read and write support for this new and advanced image format for all native Haiku applications.
 
-## Hardware compatibility
+## WebPositive
 
-## Sound
+HaikuWebKit has been synchronized to an up-to-date version of upstream WebKit, and contains many bugfixes since the previous release of Haiku. It also now uses the cURL networking backend, which resolved a large number of the network-related issues seen in previous releases.
 
-* Improved es1370 audio drivers
-* Improved hda audio drivers
+## Bootloader
 
-## Mass storage
+32-bit EFI support has been added (previous releases only supported 64-bit EFI.) It is possible to boot a 64-bit Haiku installation from a 32-bit EFI loader.
 
-* Support for SD/MMC readers on the PCI bus (SDHCI)
-* Improved ramfs driver stability
-* Improved NVMe driver performance
+# Software ports
 
-## Network
+## GTK applications!
 
-* Improved virtio driver performance
-* Updated wireless network drivers to match with FreeBSD 13
-* Remove the "wavelan" WiFi driver which supported only some very old 11Mbps Wifi cards
+Thanks to (at first) the new X11 compatibility layer, and (now) the new Wayland compatibility layer (more details below), there is now a working GTK3 port for Haiku! Ports of Inkscape, GIMP, and more are now available for immediate install, and more GTK applications are being added to HaikuPorts as time goes on.
 
-## USB
+One of the newly available GTK applications is GNOME Web aka. Epiphany, which is based on a very recent version of WebKitGTK. This provides an unfortunately non-native but largely functional web browser for Haiku for the first time in many years, with “just works” status for major websites like YouTube and others.
 
-* Improved USB 3 drivers
+## GNU Emacs
 
-## Graphics
+Haiku has had terminal-based GNU Emacs for some time, but now (thanks to Emacs developers!) has a fully-upstreamed, polished-to-a-shine native GUI. You can install it from HaikuDepot already, or check out a development branch of Emacs and build it yourself.
 
-* Improved Intel_Extreme drivers (Gen4 through Gen7)
-* Improved NVIDIA GeForce 6200-6400 drivers
+## WINE
 
-## New Contributors
+Thanks to community member & contributor X512, Haiku now has a port of WINE! Initially based on the X11 compatibility layer, it now has a fully native Haiku windowing & input backend.
 
-Haiku saw 34 new contributors to the source code since R1/beta2
+It is somewhat limited at the moment, being available only on 64-bit Haiku and only supporting 64-bit Windows applications. It is also a bit inefficient performance-wise at present due to some limitations in Haiku, but that will likely improve with time as Haiku gains more I/O APIs.
 
-* Máximo Castañeda
-* Jaidyn Ann
-* Han Pengfei
-* David Sebek
-* Coldfirex
-* Lt-Henry
-* Jeremy Visser
-* beaglejoe
-* Sylvain78
-* roired
-* Pawan Wadhwani
-* Mitsunori YOSHIDA
-* Jessica Tallon
-* Andriy Voskoboinyk
-* Anarchos
-* syedsouban
-* Siddhant Gupta
-* Shannon Mackey
-* Sean Long
-* Saloni
-* ROIRED XSoto
-* rofl0r
-* Oishika Pradhan
-* Mark Barnett
-* Maciej Bałuta
-* jpdw
-* jiceland
-* JadedTuna
-* HrithikKumar49
-* Heinrich Schuchardt
-* Daniel Schaefer
-* Bailey Carlson
-* Andriy Gapon
-* Adam Fowler
+## Xlib (X11) compatibility layer
 
-## Source code
+There is now a native compatibility layer for X11 available in the package repositories. Instead of running a full X server as XQuartz or other X11 compatibility packages do on other operating systems, it directly handles Xlib API calls and translates them into Haiku API calls, instead. You can read some more about what and why this was done, install the package directly via pkgman install xlibe_devel, or check out its source code.
 
-The source code of Haiku itself can be accessed from GitHub at https://github.com/haiku/haiku or via Haiku's Git instance at https://git.haiku-os.org.
+This was originally written to port GTK3, and so it may be missing some (or many) API calls needed by other applications, though it has been tested with a wide variety of X11 applications and most non-Motif ones seem to at least partially work already.
 
-=> https://github.com/haiku/haiku https://github.com/haiku/haiku
-=> https://git.haiku-os.org https://git.haiku-os.org
+## Wayland compatibility layer
 
-## Reporting issues
+Yes, in addition to an X11 compatibility layer, we now also have one for Wayland! It is a little more complicated than the one for X11, running an “in-process Wayland server” for each application instead of translating C API calls directly. The GTK3 port now is built atop this instead of the X11 compatibility layer for both features and performance reasons.
 
-There are almost 3,600 open tickets on Haiku's bug tracker and over 13,432 closed items.  If you find what you believe to be an issue, please search the bug tracker to see if it has already been reported, and if not, file a new ticket at https://dev.haiku-os.org/.
+# Changes & bug fixes
 
-=> https://dev.haiku-os.org/ https://dev.haiku-os.org/
+Hundreds of bugs and other minor issues were resolved since the previous release, and there are simply too many to try and list them all here. Virtually every area of the system received some amount of attention, and the result is Haiku’s most polished and stable release yet, even if some rough edges remain here and there.
 
-For information about major issues that have been fixed since the release, visit https://dev.haiku-os.org/wiki/R1/Beta3/ReleaseAddendum.
+## Improved POSIX compatibility
 
-=> https://dev.haiku-os.org/wiki/R1/Beta3/ReleaseAddendum https://dev.haiku-os.org/wiki/R1/Beta3/ReleaseAddendum
+Haiku is always looking to see how we can improve our adherence to POSIX and make it easier for developers to port their software. There are too many changes in this area to individually list, but here are some highlights:
 
-For more help, take the 'Quick Tour' and read the 'User Guide', both linked on the Haiku desktop. WebPositive opens by default with our 'Welcome' page which provides useful information and many helpful links, as does the Haiku Project's website at https://www.haiku-os.org.
+=> Addition and implementation of locale_t and related methods.
+=> Support for C11 threads.
+=> Increased maximum argument length to match FreeBSD (roughly doubled).
+=> More portions of the C library taken from glibc replaced with musl equivalents
+=> ELF “undefined weak symbols” now supported.
+=> dl_iterate_phdr implemented.
+=> Fixed behavior of O_NOCTTY, which GPG relies on.
+=> Boot failure fixes
+=> Boot failures have wide and diverse causes, from USB driver bugs to race conditions in initialization and back again. Many problems preventing successful boots completely or intermittently both on real hardware and in virtual machines were tracked down and resolved, making it possible to at least start Haiku on a much wider variety of hardware than before.
 
-=> https://www.haiku-os.org https://www.haiku-os.org
+## NVMe driver improvements
 
-For support and/or help with anything related to Haiku, feel free to post on our forums at https://discuss.haiku-os.org, or send a message to our general mailing list at https://www.freelists.org/list/haiku so our friendly community may assist you.
+The NVMe driver now supports falling back to “polling” mode when interrupts are not working properly, handles “unaligned” transfers much more reliably, and had a number of performance improvements made to it. Support for TRIM was also implemented.
 
-=> https://discuss.haiku-os.org https://discuss.haiku-os.org
-=> https://www.freelists.org/list/haiku https://www.freelists.org/list/haiku
+## Kernel always compiled with newer GCC
 
-## Press contact
+On 32-bit x86 systems, we still use the ancient GCC 2.95 to compile many parts of the system to maintain ABI compatibility with BeOS. However, in this past development cycle, changes were made so that the kernel and drivers are always compiled with the newer GCC version (presently GCC 11), even when building most of the system with GCC 2.95.
 
-Press inquiries may be directed to our team via email at contact@haiku-os.org
+## General stabilization work
+
+A significant amount of time has been poured into work on stabilizing the whole system, with a great many kernel and driver crashes, hangs, corruptions, and more tested, tracked down, and fixed over this release’s development cycle. Overall, the system seems to be the most stable it’s ever been, with plenty of feedback from the community to this effect.
+
+# Source code
+
+The source code of Haiku itself can be accessed from the GitHub mirror or via Haiku’s own Git instance. Patches can be contributed via Gerrit.
+
+# Reporting issues
+
+There are over 3,600 open tickets on Haiku’s bug tracker and over 14,300 closed items. If you find what you believe to be an issue, please search the bug tracker to see if it has already been reported, and if not, file a new ticket on the bug tracker.
+
+For information about major issues that have been fixed since the release, visit the Release Addendum page.
+
+For more help, take the ‘Quick Tour’ and read the ‘User Guide’, both linked on the Haiku desktop.
+WebPositive opens by default with our ‘Welcome’ page which provides useful information and many helpful links, as does the Haiku Project’s website.
+
+For support and/or help with anything related to Haiku, feel free to post on our forums, join one of our IRC/Matrix/XMPP rooms, or send a message to one of our mailing lists so our friendly community may assist you.
+
+# Press contact
+
+Press inquiries may be directed to:
+
+waddlesplash (English)
+pulkomandy (French)
+humdingerb (German)
+
+All three contacts may be reached via <nickname>@gmail.

--- a/content/package.gmi
+++ b/content/package.gmi
@@ -9,14 +9,14 @@ The Haiku project offers the following official package repositories:
 
 Haiku software packages available over HTTPS. These are the official package repositories of Haiku.
 
-### R1 / Beta 3
+### R1 / Beta 4
 
 ``` Haiku Repository
-pkgman add-repo https://eu.hpkg.haiku-os.org/haiku/r1beta3/$(getarch)/current
+pkgman add-repo https://eu.hpkg.haiku-os.org/haiku/r1beta4/$(getarch)/current
 ```
 
 ``` Haikuports Repository
-pkgman add-repo https://eu.hpkg.haiku-os.org/haikuports/r1beta3/$(getarch)/current
+pkgman add-repo https://eu.hpkg.haiku-os.org/haikuports/r1beta4/$(getarch)/current
 ```
 
 ### Nightly
@@ -39,16 +39,16 @@ Haiku unoffically publishes the package repositories via IPFS. Be sure to replac
 => https://ipfs.io IPFS Information
 => https://ipfs.github.io/public-gateway-checker/ IPFS Public Gateways
 
-### R1 / Beta 3
+### R1 / Beta 4
 
 ``` Haiku Repository
 pkgman add-repo \
-  https://<gateway>/ipns/hpkg.haiku-os.org/haiku/r1beta3/$(getarch)/current
+  https://<gateway>/ipns/hpkg.haiku-os.org/haiku/r1beta4/$(getarch)/current
 ```
 
 ``` Haikuports Repository
 pkgman add-repo \
-  https://<gateway>/ipns/hpkg.haiku-os.org/haikuports/r1beta3/$(getarch)/current
+  https://<gateway>/ipns/hpkg.haiku-os.org/haikuports/r1beta4/$(getarch)/current
 ```
 
 ### Nightly


### PR DESCRIPTION
Update gemini site for r1beta4

TODO:
  * Update release date for r1beta4 once final
  * Update release notes with final copy.

**DO NOT MERGE UNTIL R1BETA4 IS RELEASED**